### PR TITLE
Remove confirmation columns in database for User registration

### DIFF
--- a/db/migrate/20210920121508_remove_confirmable_from_users.rb
+++ b/db/migrate/20210920121508_remove_confirmable_from_users.rb
@@ -1,0 +1,8 @@
+class RemoveConfirmableFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :confirmation_token, :string
+    remove_column :users, :confirmed_at, :datetime
+    remove_column :users, :confirmation_sent_at, :datetime
+    remove_column :users, :unconfirmed_email, :string
+  end
+end

--- a/db/migrate/20210920121508_remove_confirmable_from_users.rb
+++ b/db/migrate/20210920121508_remove_confirmable_from_users.rb
@@ -1,8 +1,8 @@
 class RemoveConfirmableFromUsers < ActiveRecord::Migration[6.0]
   def change
-    remove_column :users, :confirmation_token, :string
-    remove_column :users, :confirmed_at, :datetime
-    remove_column :users, :confirmation_sent_at, :datetime
-    remove_column :users, :unconfirmed_email, :string
+    remove_column :users, :confirmation_token
+    remove_column :users, :confirmed_at
+    remove_column :users, :confirmation_sent_at
+    remove_column :users, :unconfirmed_email
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_18_021008) do
+ActiveRecord::Schema.define(version: 2021_09_20_121508) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,10 +27,6 @@ ActiveRecord::Schema.define(version: 2021_09_18_021008) do
     t.decimal "balance", precision: 8, scale: 2, default: "0.0"
     t.integer "role", default: 0
     t.integer "status", default: 0
-    t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
-    t.string "unconfirmed_email"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
Removed the following unnecessary columns.
-      confirmation_token, :string
-      confirmed_at, :datetime
-      confirmation_sent_at, :datetime
-      unconfirmed_email, :string
